### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   # to run this workflow manually from the Actions tab 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync-to-hub:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/Agentic-Ai-Project/security/code-scanning/1](https://github.com/venkateshpabbati/Agentic-Ai-Project/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Since the workflow does not appear to use the `GITHUB_TOKEN` for any operations, we will set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` cannot be misused for unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
